### PR TITLE
Fix for non-english localizations + commands in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _____
     cd zram-swap-config
     chmod +x install.sh && sudo ./install.sh
     cd ..
-    rm -r zram-swap-config
+    rm -rf zram-swap-config
 
 ## Upgrade
 
@@ -133,7 +133,7 @@ sudo systemctl disable dphys-swapfile
 ## Uninstall 
 
 ```
-chmod +x /usr/local/bin/zram-swap-config-uninstall.sh && sudo /usr/local/bin/zram-swap-config-uninstall.sh
+sudo chmod +x /usr/local/bin/zram-swap-config-uninstall.sh && sudo /usr/local/bin/zram-swap-config-uninstall.sh
 ```
 
 ## Git Branches & Update

--- a/zram-swap-config
+++ b/zram-swap-config
@@ -3,7 +3,7 @@
 . /etc/zram-swap-config.conf
 
 createZramSwaps () {
-	totalmem=$(free|awk '/^Mem:/{print $2}')
+	totalmem=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
 	mem=$((( totalmem * MEM_FACTOR / 100 / SWAP_DEVICES ) * 1024 ))
 	drive_size=$((( mem * DRIVE_FACTOR ) /100 ))
 	# Check Zram Class created


### PR DESCRIPTION
The output of the `free` command is localized, so if the system locale is not English, `free|awk '/^Mem:/{print $2}'` will fail. I suggest to replace it with `awk '/MemTotal/ {print $2}' /proc/meminfo`.

Also added two minor changes to the commands in the readme file, see comparison.

Thank you for these helpful scripts!